### PR TITLE
Make nice slugs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ ruby '2.3.1'
 
 gem 'rails', '~>5.0.0'
 gem 'pg'
+gem 'friendly_id'
+gem 'puma'
 
 # Views
 gem 'autoprefixer-rails'
@@ -22,9 +24,6 @@ gem 'uglifier'
 # Image uploading
 gem 'carrierwave'
 gem 'cloudinary'
-
-# Server
-gem 'puma'
 
 # Jobs
 gem 'redis'
@@ -44,7 +43,6 @@ gem 'pundit'
 # For awesome debugging
 gem 'awesome_print', require: false
 gem 'pry-rails'
-
 
 group :development, :test do
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,8 @@ GEM
       activesupport
       capybara
       i18n
+    friendly_id (5.2.0.beta.1)
+      activerecord (>= 4.0.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hashdiff (0.3.0)
@@ -355,6 +357,7 @@ DEPENDENCIES
   faker
   font-awesome-rails
   formulaic
+  friendly_id
   i18n-tasks
   jquery-rails
   launchy

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -57,7 +57,7 @@ class EventsController < ApplicationController
   private
 
   def find_event
-    Event.find(params[:id])
+    Event.friendly.find(params[:id])
   end
 
   def event_params

--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -56,7 +56,7 @@ class NewsItemsController < ApplicationController
   private
 
   def find_news_item
-    NewsItem.find(params[:id])
+    NewsItem.friendly.find(params[:id])
   end
 
   def news_item_params

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 class Event < ApplicationRecord
+  extend FriendlyId
+
+  friendly_id :slug_candidates, use: :slugged
+
   belongs_to :location
   mount_uploader :cover_image, CoverImageUploader
 
@@ -18,5 +22,21 @@ class Event < ApplicationRecord
   def image_size
     return if cover_image.size < 5.megabytes
     errors.add(:cover_image, 'cannot be more than 5MB')
+  end
+
+  def slug_candidates
+    [
+      :name,
+      [:name, start_date],
+      [:name, start_date, location_name]
+    ]
+  end
+
+  def start_date
+    starts_at.try(:to_date)
+  end
+
+  def location_name
+    location.try(:name)
   end
 end

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -1,5 +1,27 @@
 # frozen_string_literal: true
 class NewsItem < ApplicationRecord
+  extend FriendlyId
+
+  friendly_id :slug_candidates, use: :slugged
+
   validates_presence_of :title
   validates_presence_of :description
+
+  private
+
+  def slug_candidates
+    [
+      :title,
+      [:title, created_date],
+      [:title, created_date_and_time]
+    ]
+  end
+
+  def created_date
+    created_at.try(:to_date)
+  end
+
+  def created_date_and_time
+    created_at.try(:time)
+  end
 end

--- a/app/views/news_items/_news_item.html.slim
+++ b/app/views/news_items/_news_item.html.slim
@@ -1,6 +1,6 @@
 .news_item
   .info
-    h2 = news_item.title
+    h2 = link_to news_item.title, news_item_path(news_item)
     time = l(news_item.created_at, format: :full)
     = render_markdown news_item.description
   .control

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,92 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  # Note that you must use the :slugged addon **prior** to the line which
+  # configures the sequence separator, or else FriendlyId will raise an undefined
+  # method error.
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id?` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  #
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/db/migrate/20160810194945_create_friendly_id_slugs.rb
+++ b/db/migrate/20160810194945_create_friendly_id_slugs.rb
@@ -1,0 +1,15 @@
+class CreateFriendlyIdSlugs < ActiveRecord::Migration
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, :sluggable_id
+    add_index :friendly_id_slugs, [:slug, :sluggable_type]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], :unique => true
+    add_index :friendly_id_slugs, :sluggable_type
+  end
+end

--- a/db/migrate/20160810195220_add_slug_to_event.rb
+++ b/db/migrate/20160810195220_add_slug_to_event.rb
@@ -1,0 +1,6 @@
+class AddSlugToEvent < ActiveRecord::Migration[5.0]
+  def change
+    add_column :events, :slug, :string
+    add_index :events, :slug, unique: true
+  end
+end

--- a/db/migrate/20160810202921_add_slug_to_news_item.rb
+++ b/db/migrate/20160810202921_add_slug_to_news_item.rb
@@ -1,0 +1,6 @@
+class AddSlugToNewsItem < ActiveRecord::Migration[5.0]
+  def change
+    add_column :news_items, :slug, :string
+    add_index :news_items, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160809222756) do
+ActiveRecord::Schema.define(version: 20160810202921) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,7 +37,21 @@ ActiveRecord::Schema.define(version: 20160809222756) do
     t.string   "signup_link"
     t.string   "tagline"
     t.integer  "price"
+    t.string   "slug"
     t.index ["location_id"], name: "index_events_on_location_id", using: :btree
+    t.index ["slug"], name: "index_events_on_slug", unique: true, using: :btree
+  end
+
+  create_table "friendly_id_slugs", force: :cascade do |t|
+    t.string   "slug",                      null: false
+    t.integer  "sluggable_id",              null: false
+    t.string   "sluggable_type", limit: 50
+    t.string   "scope"
+    t.datetime "created_at"
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true, using: :btree
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type", using: :btree
+    t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id", using: :btree
+    t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type", using: :btree
   end
 
   create_table "locations", force: :cascade do |t|
@@ -63,6 +77,8 @@ ActiveRecord::Schema.define(version: 20160809222756) do
     t.text     "description", null: false
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.string   "slug"
+    t.index ["slug"], name: "index_news_items_on_slug", unique: true, using: :btree
   end
 
   create_table "organizations", force: :cascade do |t|

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe EventsController do
   describe 'GET #show' do
     let(:event) { create :event }
 
-    subject { get :show, params: { id: event.id } }
+    subject { get :show, params: { id: event.slug } }
 
     it_behaves_like 'action that is allowed for guests'
 
@@ -96,14 +96,14 @@ RSpec.describe EventsController do
   describe 'GET #edit' do
     let(:event) { create :event }
 
-    subject { get :edit, params: { id: event.id } }
+    subject { get :edit, params: { id: event.slug } }
 
     it_behaves_like 'action not allowed for guests'
 
     include_context 'user is logged in' do
       it 'calls authorize' do
         expect(controller).to receive(:authorize).with(event)
-        get :edit, params: { id: event.id }
+        get :edit, params: { id: event.slug }
       end
 
       it_behaves_like 'action that redirects unauthorized user'
@@ -118,7 +118,7 @@ RSpec.describe EventsController do
     let(:event) { create :event }
     let(:event_params) { { name: 'New Event Name' } }
 
-    subject { put :update, params: { id: event.id, event: event_params } }
+    subject { put :update, params: { id: event.slug, event: event_params } }
 
     it_behaves_like 'action not allowed for guests'
 
@@ -130,13 +130,13 @@ RSpec.describe EventsController do
         context 'with valid params' do
           it 'updates the event' do
             expect do
-              put :update, params: { id: event.id, event: event_params }
+              put :update, params: { id: event.slug, event: event_params }
               event.reload
             end.to change(event, :name)
           end
 
           it 'sets the right flash' do
-            put :update, params: { id: event.id, event: event_params }
+            put :update, params: { id: event.slug, event: event_params }
             expect(response).to redirect_to events_path
             expect(controller).to set_flash[:notice].to 'Event was successfully updated'
           end
@@ -147,13 +147,13 @@ RSpec.describe EventsController do
 
           it 'does not update the event' do
             expect do
-              put :update, params: { id: event.id, event: invalid_params }
+              put :update, params: { id: event.slug, event: invalid_params }
               event.reload
             end.not_to change(event, :name)
           end
 
           it 'sets the right flash' do
-            put :update, params: { id: event.id, event: invalid_params }
+            put :update, params: { id: event.slug, event: invalid_params }
             expect(response).to have_http_status :ok
             expect(flash[:alert]).to eq 'Event could not be updated'
           end
@@ -165,7 +165,7 @@ RSpec.describe EventsController do
   describe 'DELETE #destroy' do
     let!(:event) { create :event }
 
-    subject { delete :destroy, params: { id: event.id } }
+    subject { delete :destroy, params: { id: event.slug } }
 
     it_behaves_like 'action not allowed for guests'
 

--- a/spec/controllers/news_items_controller_spec.rb
+++ b/spec/controllers/news_items_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe NewsItemsController, type: :controller do
   describe 'GET #show' do
     let(:news_item) { create :news_item }
 
-    subject { get :show, params: { id: news_item.id } }
+    subject { get :show, params: { id: news_item.slug } }
 
     it_behaves_like 'action that is allowed for guests'
     it_behaves_like 'action to be authorized with', NewsItem
@@ -91,14 +91,14 @@ RSpec.describe NewsItemsController, type: :controller do
   describe 'GET #edit' do
     let(:news_item) { create :news_item }
 
-    subject { get :edit, params: { id: news_item.id } }
+    subject { get :edit, params: { id: news_item.slug } }
 
     it_behaves_like 'action not allowed for guests'
 
     include_context 'user is logged in' do
       it 'calls authorize' do
         expect(controller).to receive(:authorize).with(news_item)
-        get :edit, params: { id: news_item.id }
+        get :edit, params: { id: news_item.slug }
       end
 
       it_behaves_like 'action that redirects unauthorized user'
@@ -113,14 +113,14 @@ RSpec.describe NewsItemsController, type: :controller do
     let(:news_item) { create :news_item }
     let(:news_item_params) { { title: 'New NewsItem Name' } }
 
-    subject { put :update, params: { id: news_item.id, news_item: news_item_params } }
+    subject { put :update, params: { id: news_item.slug, news_item: news_item_params } }
 
     it_behaves_like 'action not allowed for guests'
 
     include_context 'user is logged in' do
       it 'calls authorize' do
         expect(controller).to receive(:authorize).with(news_item)
-        put :update, params: { id: news_item.id, news_item: news_item_params }
+        put :update, params: { id: news_item.slug, news_item: news_item_params }
       end
 
       it_behaves_like 'action that redirects unauthorized user'
@@ -129,13 +129,13 @@ RSpec.describe NewsItemsController, type: :controller do
         context 'with valid params' do
           it 'updates the news_item' do
             expect do
-              put :update, params: { id: news_item.id, news_item: news_item_params }
+              put :update, params: { id: news_item.slug, news_item: news_item_params }
               news_item.reload
             end.to change(news_item, :title)
           end
 
           it 'sets the right flash' do
-            put :update, params: { id: news_item.id, news_item: news_item_params }
+            put :update, params: { id: news_item.slug, news_item: news_item_params }
             expect(response).to redirect_to news_items_path
             expect(controller).to set_flash[:notice].to eq t('news_items.update.success')
           end
@@ -146,13 +146,13 @@ RSpec.describe NewsItemsController, type: :controller do
 
           it 'does not update the news_item' do
             expect do
-              put :update, params: { id: news_item.id, news_item: invalid_params }
+              put :update, params: { id: news_item.slug, news_item: invalid_params }
               news_item.reload
             end.not_to change(news_item, :title)
           end
 
           it 'sets the right flash' do
-            put :update, params: { id: news_item.id, news_item: invalid_params }
+            put :update, params: { id: news_item.slug, news_item: invalid_params }
             expect(flash[:alert]).to eq t('news_items.update.failure')
           end
         end
@@ -163,7 +163,7 @@ RSpec.describe NewsItemsController, type: :controller do
   describe 'DELETE #destroy' do
     let!(:news_item) { create :news_item }
 
-    subject { delete :destroy, params: { id: news_item.id } }
+    subject { delete :destroy, params: { id: news_item.slug } }
 
     it_behaves_like 'action not allowed for guests'
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -27,4 +27,28 @@ RSpec.describe Event, type: :model do
     it { is_expected.to     include upcoming     }
     it { is_expected.not_to include not_upcoming }
   end
+
+  describe 'slugging' do
+    it 'handles slugging events when slugs are taken' do
+      event = create :event, name: 'Learn Ruby on Rails'
+      expect(event.slug).to eq 'learn-ruby-on-rails'
+
+      next_event = create :event, name: 'Learn Ruby on Rails', starts_at: Time.zone.parse('2017-01-25 18:00:00')
+      expect(next_event.slug).to eq 'learn-ruby-on-rails-2017-01-25'
+
+      location = create :location, name: 'A nice location'
+      another_event = create :event, name: 'Learn Ruby on Rails',
+                                     starts_at: Time.zone.parse('2017-01-25 18:00:00'),
+                                     location: location
+      expect(another_event.slug).to eq 'learn-ruby-on-rails-2017-01-25-a-nice-location'
+    end
+
+    context 'object is invalid' do
+      it 'does not set a slug' do
+        event = build :event, name: nil
+        expect(event).to be_invalid
+        expect(event.slug).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -4,4 +4,25 @@ require 'rails_helper'
 RSpec.describe NewsItem, type: :model do
   it { is_expected.to validate_presence_of :title       }
   it { is_expected.to validate_presence_of :description }
+
+  describe 'slugging' do
+    it 'handles slugging events when slugs are taken' do
+      news_item = create :news_item, title: 'A news item'
+      expect(news_item.slug).to eq 'a-news-item'
+
+      next_item = create :news_item, title: 'A news item', created_at: Time.zone.parse('2016-01-25 18:00:00')
+      expect(next_item.slug).to eq 'a-news-item-2016-01-25'
+
+      another_item = create :news_item, title: 'A news item', created_at: Time.zone.parse('2016-01-25 18:00:00')
+      expect(another_item.slug).to eq 'a-news-item-2016-01-25-18-00-00-utc'
+    end
+
+    context 'object is invalid' do
+      it 'does not set a slug' do
+        news_item = build :news_item, title: nil
+        expect(news_item).to be_invalid
+        expect(news_item.slug).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Use the friendly ID gem (https://github.com/norman/friendly_id) to generate nice slugs for our events pages. So instead of `events/4` we can see `events/learn_rails` in the url. Much better.
